### PR TITLE
Fix bug for installation on x86 systems

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -15,8 +15,7 @@ source /usr/share/yunohost/helpers
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=1
-ls -la $install_dir
-find / -name cjdroute 2>/dev/null
+
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$install_dir"
 


### PR DESCRIPTION
## Problem

- Installation was failing on x86 systems

## Solution

- set in_subdir = false in resources in manifest

## PR Status

- [ X] Code finished and ready to be reviewed/tested
- [ X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
