### PR TITLE
remove nobackground and fix service restarting ability

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,8 +6,9 @@ After=network.target cjdns.service
 User=root
 Group=root
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=/bin/bash -c '__INSTALL_DIR__/cjdroute < __INSTALL_DIR__/cjdroute.conf'
-ExecStartPost=/bin/bash -c 'sleep 3 && __INSTALL_DIR__/cjdns-proxy-server &'
+ExecStartPre=/bin/bash -c '__INSTALL_DIR__/cjdroute < __INSTALL_DIR__/cjdroute.conf'
+ExecStart=/bin/bash -c 'sleep 3 && __INSTALL_DIR__/cjdns-proxy-server'
+ExecStop=/bin/bash -c 'killall cjdroute'
 KillMode=process
 Restart=no
 

--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,6 @@ $install_dir/cjdroute --genconf | $install_dir/cjdroute --cleanconf > $install_d
 
 jq '.security[0].setuser = 0' $install_dir/cjdroute.conf > $install_dir/cjdroute.conf.tmp && mv $install_dir/cjdroute.conf.tmp $install_dir/cjdroute.conf
 jq '.security[0].seccomp = 0' $install_dir/cjdroute.conf > $install_dir/cjdroute.conf.tmp && mv $install_dir/cjdroute.conf.tmp $install_dir/cjdroute.conf
-jq '.noBackground = 1' $install_dir/cjdroute.conf > $install_dir/cjdroute.conf.tmp && mv $install_dir/cjdroute.conf.tmp $install_dir/cjdroute.conf
 
 #=================================================
 # UPGRADE PEERS


### PR DESCRIPTION
## Problem

- problem with restarting the service correctly

## Solution

- removed noBackground on cjdns and set proxy to start without '&'

## PR Status

- [ X] Code finished and ready to be reviewed/tested
- [ X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
